### PR TITLE
docs: add Sec3's X-Ray Toolchain to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ We highly recommend using [Anchor](https://www.anchor-lang.com), a framework for
 - [Solana playground](https://beta.solpg.io/) 
 - [Rust playground](https://play.rust-lang.org/)
 - [Sec3's IDL Guesser](https://github.com/sec3-service/IDLGuesser): Reverse engineers IDL from onchain programs for easier integration
+- [Sec3's X-Ray Toolchain](https://github.com/sec3-product/x-ray): Static analysis CLI for Solana programs written in Rust
 - [Trail of Bits's Anchor X-ray](https://github.com/crytic/anchorx-ray): Visualizes accounts in Anchor programs
 - [John Saigle's Anchor version detector](https://github.com/johnsaigle/anchor-version-detector): Helps figure out which versions of Rust, Solana, and Anchor are compatible with a given Anchor project.
 - [Ackee's Trident](https://ackee.xyz/trident/docs/latest/): Fuzzing framework for Solana


### PR DESCRIPTION
Hi - opening this PR to add sec3's X-Ray Toolchain to the Tools section. It's an open-source (AGPL-3.0) CLI for static analysis of Solana programs in Rust that we've been maintaining at sec3-product/x-ray.

Note there's already "Trail of Bits's Anchor X-ray" on the list (a different tool that visualizes Anchor account structures). I've named the entry "Sec3's X-Ray Toolchain" to keep them distinct, following the "Sec3's IDL Guesser" naming already on the list. Happy to adjust the wording if you think the overlap is still confusing.

Disclosure: I'm affiliated with sec3, so please push back or close this if the fit isn't right.

Thanks for maintaining the list.