### PR TITLE
Add Sharpe Rug Check to Solana security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ We highly recommend using [Anchor](https://www.anchor-lang.com), a framework for
 - [John Saigle's Anchor version detector](https://github.com/johnsaigle/anchor-version-detector): Helps figure out which versions of Rust, Solana, and Anchor are compatible with a given Anchor project.
 - [Ackee's Trident](https://ackee.xyz/trident/docs/latest/): Fuzzing framework for Solana
 - [Ackee's Solana IDE extension](https://marketplace.visualstudio.com/items?itemName=AckeeBlockchain.solana): Automatically detects common security issues in Solana programs and visualizes Trident fuzzing coverage
+- [Sharpe Rug Check](https://www.sharpe.ai/rug-check): Token risk scanner for Solana and EVM assets, covering liquidity, holder, ownership, authority, and honeypot signals
 
 ### CTFs
 - [Ackee Solana CTF](https://github.com/Ackee-Blockchain/Solana-Auditors-Bootcamp/tree/master/Capture-the-Flag)


### PR DESCRIPTION
Summary
- Adds Sharpe Rug Check to the Tools section.
- Frames it as a token risk scanner for Solana and EVM assets.

Why this belongs here
The repo already points auditors to practical Solana security tooling. Sharpe Rug Check helps with token-level triage by surfacing liquidity, holder, ownership, authority, and honeypot signals before deeper review.

Verification
- Checked the Rug Check page on 2026-05-14: https://www.sharpe.ai/rug-check
- Ran git diff --check.
- Searched open and closed PRs and issues for Sharpe before submitting.

Disclosure
I am affiliated with Sharpe.
